### PR TITLE
feat(consume): event.join KafkaConsumer 리스너 구현 및 설정 추가

### DIFF
--- a/src/main/java/com/hj/kafkaeventrush/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/hj/kafkaeventrush/config/KafkaConsumerConfig.java
@@ -1,0 +1,41 @@
+package com.hj.kafkaeventrush.config;
+
+import com.hj.kafkaeventrush.dto.EventJoinMessage;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, EventJoinMessage> eventJoinConsumerFactory() {
+        JsonDeserializer<EventJoinMessage> valueDeserializer = new JsonDeserializer<>(EventJoinMessage.class);
+        valueDeserializer.addTrustedPackages("*");
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "event-consumer-group");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
+
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), valueDeserializer);
+    }
+
+    @Bean(name = "eventJoinKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, EventJoinMessage> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, EventJoinMessage> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(eventJoinConsumerFactory());
+        factory.setConcurrency(3);
+        return factory;
+    }
+}

--- a/src/main/java/com/hj/kafkaeventrush/config/KafkaProducerConfig.java
+++ b/src/main/java/com/hj/kafkaeventrush/config/KafkaProducerConfig.java
@@ -22,8 +22,8 @@ public class KafkaProducerConfig {
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        // config.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, "org.apache.kafka.clients.producer.RoundRobinPartitioner");
-        // config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        //config.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, "org.apache.kafka.clients.producer.RoundRobinPartitioner");
+        //config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
         return new DefaultKafkaProducerFactory<>(config);
     }
 

--- a/src/main/java/com/hj/kafkaeventrush/consumer/EventJoinConsumer.java
+++ b/src/main/java/com/hj/kafkaeventrush/consumer/EventJoinConsumer.java
@@ -1,0 +1,25 @@
+package com.hj.kafkaeventrush.consumer;
+
+import com.hj.kafkaeventrush.dto.EventJoinMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class EventJoinConsumer {
+
+    @KafkaListener(
+            topics = "event.join",
+            groupId = "event-consumer-group",
+            containerFactory = "eventJoinKafkaListenerContainerFactory"
+    )
+    public void consume(ConsumerRecord<String, EventJoinMessage> record) {
+        int partition = record.partition();
+        long offset = record.offset();
+        EventJoinMessage message = record.value();
+
+        log.info("Partition: {}, Offset: {}, UserId: {}, Time: {}", partition, offset, message.getUserId(), message.getRequestTime());
+    }
+}


### PR DESCRIPTION
- event.join 토픽을 수신하는 EventJoinConsumer 생성
- 수신 메시지에서 partition, offset, userId, requestTime 로그 출력